### PR TITLE
Alteração do nome do projeto de Newshub para Synapse.

### DIFF
--- a/documentation/config/_default/hugo.yaml
+++ b/documentation/config/_default/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://unb-mds.github.io/2025-2-NewsHub/"
+baseURL: "https://unb-mds.github.io/2025-2-Synapse/"
 
 # LANGUAGE
 defaultContentLanguage: en

--- a/documentation/config/development/hugo.yaml
+++ b/documentation/config/development/hugo.yaml
@@ -1,1 +1,1 @@
-baseURL: "https://unb-mds.github.io/2025-2-NewsHub/"
+baseURL: "https://unb-mds.github.io/2025-2-Synapse/"

--- a/documentation/config/production/hugo.yaml
+++ b/documentation/config/production/hugo.yaml
@@ -1,1 +1,1 @@
-baseURL: "https://unb-mds.github.io/2025-2-NewsHub/"
+baseURL: "https://unb-mds.github.io/2025-2-Synapse/"

--- a/documentation/config/staging/hugo.yaml
+++ b/documentation/config/staging/hugo.yaml
@@ -1,1 +1,1 @@
-baseURL: "https://unb-mds.github.io/2025-2-NewsHub/"
+baseURL: "https://unb-mds.github.io/2025-2-Synapse/"

--- a/documentation/content/_index.md
+++ b/documentation/content/_index.md
@@ -22,7 +22,7 @@ Seu grande diferencial está na capacidade de **oferecer notícias de forma pers
 
 - [Protótipo](https://www.figma.com/design/SxR5ObmFxAvHzOs1Jw0AnY/Prot%C3%B3tipos?node-id=0-1&t=MguUSpJBo5u3gB9V-1)  
 - [Lean Inception](https://www.figma.com/board/qob1Oi0suKGhkMU3ag3sD2/Lean-Inception?node-id=0-1&t=lH5c0CJxaFEqLAbm-1)  
-- [Repositório no GitHub](https://github.com/unb-mds/2025-2-NewsHub)  
+- [Repositório no GitHub](https://github.com/unb-mds/2025-2-Synapse)  
 
 ---
 

--- a/documentation/content/getting_started/_index.md
+++ b/documentation/content/getting_started/_index.md
@@ -22,8 +22,8 @@ Este guia explica como executar o projeto Synapse, incluindo backend, frontend, 
 
 1. **Clonar o repositório**  
     ```
-    git clone https://github.com/unb-mds/NewsHub.git
-    cd NewsHub
+    git clone https://github.com/unb-mds/Synapse.git
+    cd Synapse
     ```
 
 2. **Criar arquivo de ambiente**  

--- a/documentation/docs/404.html
+++ b/documentation/docs/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Synapse Documentation</title>
   
-  <link rel="stylesheet" href="/2025-2-NewsHub/css/synapse.min.css">
+  <link rel="stylesheet" href="/2025-2-Synapse/css/synapse.min.css">
 </head>
 <body class="syn-app">
   <nav class="syn-sidebar">
@@ -19,7 +19,7 @@
   <main class="main">
     
   <div class="container">
-  <p><a href="https://unb-mds.github.io/2025-2-NewsHub/" class="btn btn-primary">Back to home page</a></p>
+  <p><a href="https://unb-mds.github.io/2025-2-Synapse/" class="btn btn-primary">Back to home page</a></p>
 </div>
 
   </main>

--- a/documentation/docs/about_project/index.html
+++ b/documentation/docs/about_project/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Synapse Documentation</title>
   
-  <link rel="stylesheet" href="/2025-2-NewsHub/css/synapse.min.css">
+  <link rel="stylesheet" href="/2025-2-Synapse/css/synapse.min.css">
 </head>
 <body class="syn-app">
   <nav class="syn-sidebar">

--- a/documentation/docs/admin/config.yml
+++ b/documentation/docs/admin/config.yml
@@ -2,7 +2,7 @@ backend:
   branch: main
   name: git-gateway
 
-display_url: "https://unb-mds.github.io/2025-2-NewsHub/"
+display_url: "https://unb-mds.github.io/2025-2-Synapse/"
 
 local_backend: true
 locale: en

--- a/documentation/docs/getting_started/index.html
+++ b/documentation/docs/getting_started/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Synapse Documentation</title>
   
-  <link rel="stylesheet" href="/2025-2-NewsHub/css/synapse.min.css">
+  <link rel="stylesheet" href="/2025-2-Synapse/css/synapse.min.css">
 </head>
 <body class="syn-app">
   <nav class="syn-sidebar">
@@ -36,8 +36,8 @@
 <ol>
 <li>
 <p><strong>Clonar o repositório</strong></p>
-<div class="highlight"><pre tabindex="0" style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4;"><code class="language-bash" data-lang="bash"><span style="display:flex;"><span>git clone https://github.com/unb-mds/NewsHub.git
-</span></span><span style="display:flex;"><span>cd NewsHub
+<div class="highlight"><pre tabindex="0" style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4;"><code class="language-bash" data-lang="bash"><span style="display:flex;"><span>git clone https://github.com/unb-mds/Synapse.git
+</span></span><span style="display:flex;"><span>cd Synapse
 </span></span></code></pre></div></li>
 <li>
 <p><strong>Criar arquivo de ambiente</strong></p>

--- a/documentation/docs/index.html
+++ b/documentation/docs/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Synapse Documentation</title>
   
-  <link rel="stylesheet" href="/2025-2-NewsHub/css/synapse.min.css">
+  <link rel="stylesheet" href="/2025-2-Synapse/css/synapse.min.css">
 </head>
 <body class="syn-app">
   <nav class="syn-sidebar">
@@ -27,7 +27,7 @@
 <ul>
 <li><a href="https://www.figma.com/design/SxR5ObmFxAvHzOs1Jw0AnY/Prot%C3%B3tipos?node-id=0-1&amp;t=MguUSpJBo5u3gB9V-1">Protótipo no Figma</a></li>
 <li><a href="https://www.figma.com/board/qob1Oi0suKGhkMU3ag3sD2/Lean-Inception?node-id=0-1&amp;t=lH5c0CJxaFEqLAbm-1">Lean Inception</a></li>
-<li><a href="https://github.com/unb-mds/2025-2-NewsHub">Repositório no GitHub</a></li>
+<li><a href="https://github.com/unb-mds/2025-2-Synapse">Repositório no GitHub</a></li>
 </ul>
 <hr>
 <h2 id="-autores">👥 Autores</h2>

--- a/documentation/docs/index.xml
+++ b/documentation/docs/index.xml
@@ -2,30 +2,30 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Início on Synapse Documentation</title>
-    <link>https://unb-mds.github.io/2025-2-NewsHub/</link>
+    <link>https://unb-mds.github.io/2025-2-Synapse/</link>
     <description>Recent content in Início on Synapse Documentation</description>
     <generator>Hugo</generator>
     <language>en</language>
-    <atom:link href="https://unb-mds.github.io/2025-2-NewsHub/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://unb-mds.github.io/2025-2-Synapse/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title></title>
-      <link>https://unb-mds.github.io/2025-2-NewsHub/admin/config.yml</link>
+      <link>https://unb-mds.github.io/2025-2-Synapse/admin/config.yml</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://unb-mds.github.io/2025-2-NewsHub/admin/config.yml</guid>
+      <guid>https://unb-mds.github.io/2025-2-Synapse/admin/config.yml</guid>
       <description></description>
     </item>
     <item>
       <title></title>
-      <link>https://unb-mds.github.io/2025-2-NewsHub/about_project/</link>
+      <link>https://unb-mds.github.io/2025-2-Synapse/about_project/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://unb-mds.github.io/2025-2-NewsHub/about_project/</guid>
+      <guid>https://unb-mds.github.io/2025-2-Synapse/about_project/</guid>
       <description>&lt;h1 id=&#34;proposta-de-projeto-synapse&#34;&gt;Proposta de Projeto: Synapse&lt;/h1&gt;&#xA;&lt;h2 id=&#34;1-título-do-projeto&#34;&gt;1. Título do Projeto&lt;/h2&gt;&#xA;&lt;p&gt;Synapse: Plataforma de Notícias Inteligente com Agregação via API, Personalização e Sistema de Recomendação.&lt;/p&gt;&#xA;&lt;h2 id=&#34;2-resumo&#34;&gt;2. Resumo&lt;/h2&gt;&#xA;&lt;p&gt;O projeto Synapse propõe o desenvolvimento de uma plataforma web inovadora para descoberta e consumo de notícias. Utilizando uma API dedicada (GNews), o sistema agregará artigos de fontes globais. Os usuários poderão navegar por notícias categorizadas, aplicar filtros avançados e receber recomendações personalizadas com base em seu comportamento. Um diferencial importante é a newsletter diária opcional, que entrega resumos gerados por IA, agrupando diferentes perspectivas sobre o mesmo evento e alinhando o conteúdo aos interesses de cada usuário.&lt;/p&gt;</description>
     </item>
     <item>
       <title></title>
-      <link>https://unb-mds.github.io/2025-2-NewsHub/getting_started/</link>
+      <link>https://unb-mds.github.io/2025-2-Synapse/getting_started/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://unb-mds.github.io/2025-2-NewsHub/getting_started/</guid>
+      <guid>https://unb-mds.github.io/2025-2-Synapse/getting_started/</guid>
       <description>&lt;h1 id=&#34;como-rodar-o-projeto&#34;&gt;Como rodar o projeto&lt;/h1&gt;&#xA;&lt;p&gt;Este guia explica como executar o projeto Synapse, incluindo backend, frontend e banco de dados, tanto via Docker (recomendado) quanto em ambiente local para desenvolvimento.&lt;/p&gt;&#xA;&lt;hr&gt;&#xA;&lt;h2 id=&#34;pré-requisitos&#34;&gt;Pré-requisitos&lt;/h2&gt;&#xA;&lt;ul&gt;&#xA;&lt;li&gt;&lt;strong&gt;Git&lt;/strong&gt; (para clonar o repositório)&lt;/li&gt;&#xA;&lt;li&gt;&lt;strong&gt;Docker Desktop&lt;/strong&gt; (para orquestração dos serviços)&lt;/li&gt;&#xA;&lt;li&gt;&lt;strong&gt;Python 3.12+&lt;/strong&gt; (para desenvolvimento local do backend)&lt;/li&gt;&#xA;&lt;li&gt;&lt;strong&gt;Node.js e npm&lt;/strong&gt; (para desenvolvimento local do frontend)&lt;/li&gt;&#xA;&lt;li&gt;&lt;strong&gt;Software de gerenciamento de banco de dados&lt;/strong&gt; (opcional, ex: DBeaver, TablePlus, pgAdmin)&lt;/li&gt;&#xA;&lt;/ul&gt;&#xA;&lt;hr&gt;&#xA;&lt;h2 id=&#34;execução-recomendada-docker&#34;&gt;Execução Recomendada: Docker&lt;/h2&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;&#xA;&lt;p&gt;&lt;strong&gt;Clonar o repositório&lt;/strong&gt;&lt;/p&gt;</description>
     </item>
   </channel>

--- a/documentation/docs/sitemap.xml
+++ b/documentation/docs/sitemap.xml
@@ -2,10 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://unb-mds.github.io/2025-2-NewsHub/about_project/</loc>
+    <loc>https://unb-mds.github.io/2025-2-Synapse/about_project/</loc>
   </url><url>
-    <loc>https://unb-mds.github.io/2025-2-NewsHub/getting_started/</loc>
+    <loc>https://unb-mds.github.io/2025-2-Synapse/getting_started/</loc>
   </url><url>
-    <loc>https://unb-mds.github.io/2025-2-NewsHub/</loc>
+    <loc>https://unb-mds.github.io/2025-2-Synapse/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
## Descrição
Este PR realiza a alteração do nome do projeto em **todas as páginas, configurações e referências internas**, substituindo **Newshub** por **Synapse**.  
O objetivo é alinhar a identidade do projeto com a nova denominação oficial.

## Impacto
- Todas as rotas, títulos e labels que anteriormente exibiam **Newshub** agora exibem **Synapse**.
- Não há alterações de comportamento funcional além da troca de nome.
- Caso scripts externos, automações ou integrações ainda utilizem `Newshub`, será necessário atualizar para `Synapse`.

## Testes
- Verificado que todas as páginas renderizadas apresentam o novo nome.
- Testada consistência dos arquivos de configuração após a alteração.
- Verificar nova url com nome do projeto atualizado

## Checklist
- [x] Nome atualizado em todas as páginas
- [x] Variáveis de configuração revisadas
- [x] Documentação ajustada

---
